### PR TITLE
0.4.0 Version. New proto version improvments.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.4.0
+ - Update version of Sentry protocol to '7'
+ - Add possibility for custom fields to tags via `fields_to_tags`
+ - Add `fingerprint`, `release`, `environment` attributes
+ - Be careful. Old parameter `fields_to_tags` was renamed to `all_fields_to_tags`
 ## 0.2.0
  - Improving sentry.rb script based on antho31/logstash-output-sentry and bigpandaio/logstash-output-sentry projects.
  - Creating documentation (starting from bigpandaio/logstash-output-sentry with some fixes for the differences that we have introduced to the code).

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ sentry {
   'secret' => "596d005d20274474991a2fb8c33040b8"
   'msg' => "Message you want"
   'level_tag' => "fatal"
-  'fields_to_tags' => true
+  'all_fields_to_tags' => true
 }
 ```
 
@@ -92,8 +92,21 @@ sentry {
   'secret' => "596d005d20274474991a2fb8c33040b8"
   'msg' => "Message you want"
   'level_tag' => "fatal"
-  'fields_to_tags' => true
+  'all_fields_to_tags' => true
   'strim_timestamp' => true
+}
+```
+* You can control event collation in Sentry via `fingerprint` option. [See more](https://docs.getsentry.com/hosted/learn/rollups/#custom-grouping).
+```ruby
+output {
+  sentry {
+    'host' => "localhost:9000"
+    'use_ssl' => false
+    'project_id' => "yourprojectid"
+    'key' => "yourkey"
+    'secret' => "yoursecretkey"
+    'fingerprint' => ["%{traceback_id_field_from_event}","static_field"]
+  }
 }
 ```
 
@@ -159,7 +172,7 @@ output {
     document_type  => "%{type}"
   }
   sentry {
-    fields_to_tags => true
+    fields_to_tags => ["user", "type"]
     host           => "%{[@metadata][sentry][host]}"
     key            => "%{[@metadata][sentry][key]}"
     level_tag      => "%{[@metadata][sentry][severity]}"

--- a/logstash-output-sentry.gemspec
+++ b/logstash-output-sentry.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'logstash-output-sentry'
-  s.version = '0.3.1'
+  s.version = '0.4.0'
   s.licenses = ['Apache License (2.0)']
   s.summary = 'This output plugin sends messages to any sentry server.'
   s.description = 'This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install logstash-output-sentry. This gem is not a stand-alone program.'


### PR DESCRIPTION
## 0.4.0
- Update version of Sentry protocol to '7'
- Add possibility for custom fields to tags via `fields_to_tags`
- Add `fingerprint`, `release`, `environment` attributes
- Be careful. Old parameter `fields_to_tags` was renamed to `all_fields_to_tags`
