### PR TITLE
Fix string templating for key, url, secret and project_id fields

### DIFF
--- a/lib/logstash/outputs/sentry.rb
+++ b/lib/logstash/outputs/sentry.rb
@@ -124,10 +124,10 @@ class LogStash::Outputs::Sentry < LogStash::Outputs::Base
     auth_header = "Sentry sentry_version=5," +
       "sentry_client=raven_logstash/0.4.0," +
       "sentry_timestamp=#{timestamp.to_i}," +
-      "sentry_key=#{@key}," +
-      "sentry_secret=#{@secret}"
+      "sentry_key=#{event.sprintf(@key)}," +
+      "sentry_secret=#{event.sprintf(@secret)}"
 
-    url = "#{@url}/#{@project_id}/store/"
+    url = "#{event.sprintf(@url)}/#{event.sprintf(@project_id)}/store/"
 
     require 'http'
     response = HTTP.post(url, :body => packet.to_json, :headers => {:"X-Sentry-Auth" => auth_header})

--- a/logstash-output-sentry.gemspec
+++ b/logstash-output-sentry.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'logstash-output-sentry'
-  s.version = '0.4.1'
+  s.version = '0.4.2'
   s.licenses = ['Apache-2.0']
   s.summary = 'This output plugin sends messages to any sentry server.'
   s.description = 'This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install logstash-output-sentry. This gem is not a stand-alone program.'


### PR DESCRIPTION
It seems that the changes from commit 11226f0ea7fdecd1ae189f5b6939d7643f7e79e2 that allowed to use templating for configuration were overriden in 568728d6ed8684e0be11feb0a16e136aadb4ce28 by @saraedum.
The result broke the possibility to use `key => "%{[@metadata][sentry][key]}"` as described in the documentation.

This brings back this behaviour which comes in handy in our use case.

Happy to improve on this if anything seems broken.