### PR TITLE
Made compatible with latest logstash and sentry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.4.3
+ - Bumped `json` and `logstash-core-plugin-api` for compatibility with logstash 8.X
+ - Removed deprecated secret option in the sentry configuration
+
 ## 0.4.2
  - Fix string templating for key, url, secret and project_id fields
 

--- a/README.md
+++ b/README.md
@@ -29,9 +29,9 @@ When installing from official repository as suggested below, the installation pa
 It's important to note that Sentry should not be thought of as a log stream, but as an aggregator.
 It fits somewhere in-between a simple metrics solution (such as Graphite) and a full-on log stream aggregator (like Logstash).
 
-* In Sentry, generate and get your client key (Settings -> Client key). The client key has this form:
+* In Sentry, generate and get your client key (Settings -> Client Keys (DSN)). The client key has this form:
 ```
-[http|https]://[key]:[secret]@[host]/[project_id]
+[http|https]://[key]@[host]/[project_id]
 ```
 
 * Setup logstash to write to sentry:
@@ -39,7 +39,6 @@ It fits somewhere in-between a simple metrics solution (such as Graphite) and a 
 output {
   sentry {
     'key' => "yourkey"
-    'secret' => "yoursecret"
     'project_id' => "yourprojectid"
   }
 }
@@ -51,7 +50,6 @@ output {
   sentry {
     'url' => "http://local.sentry:9000/api"
     'key' => "yourkey"
-    'secret' => "yoursecret"
     'project_id' => "yourprojectid"
   }
 }
@@ -69,7 +67,6 @@ output {
     'user_value' => "nobody" # sets the user to the constant "nobody"
 
     'key' => "yourkey"
-    'secret' => "yoursecret"
     'project_id' => "yourprojectid"
   }
 }
@@ -102,7 +99,6 @@ filter {
         "[@metadata][sentry][host]"     => "192.168.1.101"
         "[@metadata][sentry][pid]"      => "2"
         "[@metadata][sentry][key]"      => "d3921923d34a4344878f7b83e2061229"
-        "[@metadata][sentry][secret]"   => "d0163ef306c04148aee49fe4ce7621b1"
       }
     }
   }
@@ -114,7 +110,6 @@ filter {
         "[@metadata][sentry][host]"     => "192.168.1.101"
         "[@metadata][sentry][pid]"      => "3"
         "[@metadata][sentry][key]"      => "d398098q2349883e206178098"
-        "[@metadata][sentry][secret]"   => "da098d890f098d09809f6098c87e0"
       }
     }
   }
@@ -126,7 +121,6 @@ filter {
         "[@metadata][sentry][host]"     => "192.168.1.150"
         "[@metadata][sentry][pid]"      => "4"
         "[@metadata][sentry][key]"      => "d39dc435326d987d5678e98d76cf78098"
-        "[@metadata][sentry][secret]"   => "07d09876d543d2a345e43c4e567d"
       }
     }
   }
@@ -139,7 +133,6 @@ output {
 
     project_id     => "%{[@metadata][sentry][pid]}"
     key            => "%{[@metadata][sentry][key]}"
-    secret         => "%{[@metadata][sentry][secret]}"
   }
 }
 ```

--- a/lib/logstash/outputs/sentry.rb
+++ b/lib/logstash/outputs/sentry.rb
@@ -10,10 +10,9 @@ class LogStash::Outputs::Sentry < LogStash::Outputs::Base
   # Sentry API URL
   config :url, :validate => :uri, :required => false, :default => 'https://app.getsentry.com/api'
 
-  # Project id, key and secret
+  # Project id and key
   config :project_id, :validate => :string, :required => true
   config :key, :validate => :string, :required => true
-  config :secret, :validate => :string, :required => true
 
   def self.sentry_key(name, field_default=nil, value_default=nil)
     name = name.to_s if name.is_a?(Symbol)
@@ -121,11 +120,10 @@ class LogStash::Outputs::Sentry < LogStash::Outputs::Base
   end
 
   def send_packet(event, packet, timestamp)
-    auth_header = "Sentry sentry_version=5," +
+    auth_header = "Sentry sentry_version=7," +
       "sentry_client=raven_logstash/0.4.0," +
       "sentry_timestamp=#{timestamp.to_i}," +
-      "sentry_key=#{event.sprintf(@key)}," +
-      "sentry_secret=#{event.sprintf(@secret)}"
+      "sentry_key=#{event.sprintf(@key)}"
 
     url = "#{event.sprintf(@url)}/#{event.sprintf(@project_id)}/store/"
 

--- a/logstash-output-sentry.gemspec
+++ b/logstash-output-sentry.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'logstash-output-sentry'
-  s.version = '0.4.2'
+  s.version = '0.4.3'
   s.licenses = ['Apache-2.0']
   s.summary = 'This output plugin sends messages to any sentry server.'
   s.description = 'This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install logstash-output-sentry. This gem is not a stand-alone program.'
@@ -18,8 +18,8 @@ Gem::Specification.new do |s|
   s.metadata = { 'logstash_plugin' => 'true', 'logstash_group' => 'output' }
 
   # Gem dependencies
-  s.add_runtime_dependency 'logstash-core-plugin-api', '>= 1.60', '< 3.0'
-  s.add_runtime_dependency 'json', '>= 1.8.0', '< 2.0.0'
+  s.add_runtime_dependency 'logstash-core-plugin-api', '>= 2.1.16', '< 3.0'
+  s.add_runtime_dependency 'json', '>= 2.0.0', '< 3.0.0'
   s.add_development_dependency 'logstash-devutils', '>= 1.0.0', '< 2.0.0'
   s.add_development_dependency 'logstash-codec-plain', '>= 3.0.0', '< 4.0.0'
 end


### PR DESCRIPTION
There was a dependency issue when trying to install the gem on logstash 8.6.1 due to differing `json` versions. I pinned the `logstash-core-plugin-api` to `>= 2.1.16` as that is what is internally running inside logstash 8.6.1 and essentially I only verified that this will work for that constellation. 

I also removed the usage of 'secret' for the API access to sentry as it has become deprecated/optional. Not an essential change but as a sentry beginner it was a bit confusing to still have it there.